### PR TITLE
Add not supported screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@peculiar/fortify-tools",
   "homepage": "https://tools.fortifyapp.com",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "author": "PeculiarVentures Team",
   "license": "MIT",
   "private": true,

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -6,6 +6,7 @@ import { CertificatesList } from "./components/certificates-list";
 import { CertificatesSidebar } from "./components/certificates-sidebar";
 import { CertificatesProvidersList } from "./components/certificates-providers-list";
 import { CertificatesTopbar } from "./components/certificates-topbar";
+import { ConnectionNotSupported } from "./components/connection-not-supported";
 import { useCertificateViewerDialog } from "./dialogs/certificate-viewer-dialog";
 import { useCertificateDeleteDialog } from "./dialogs/certificate-delete-dialog";
 import { useSortList } from "./hooks/sort-list";
@@ -96,6 +97,10 @@ export function App() {
 
   const { open: handleProviderInfoDialogOpen, dialog: providerInfoDialog } =
     useProviderInfoDialog({ providers });
+
+  if (fetching.connectionSupport === "rejected") {
+    return <ConnectionNotSupported />;
+  }
 
   return (
     <>

--- a/src/components/connection-not-supported/ConnectionNotSupported.stories.tsx
+++ b/src/components/connection-not-supported/ConnectionNotSupported.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ConnectionNotSupported } from "./ConnectionNotSupported";
+
+const meta: Meta<typeof ConnectionNotSupported> = {
+  title: "Components/ConnectionNotSupported",
+  component: ConnectionNotSupported,
+  tags: ["!autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof ConnectionNotSupported>;
+
+export const Default: Story = {};

--- a/src/components/connection-not-supported/ConnectionNotSupported.test.tsx
+++ b/src/components/connection-not-supported/ConnectionNotSupported.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing";
+import { ConnectionNotSupported } from "./ConnectionNotSupported";
+
+describe("<ConnectionNotSupported />", () => {
+  it("Should render", async () => {
+    render(<ConnectionNotSupported />);
+
+    expect(
+      screen.getByText(
+        /Unfortunately Fortify isn’t available for mobile devices yet/
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Please try again from a Windows, macOS, or Linux computer/
+      )
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("link", {
+        name: "Home page",
+      })
+    ).toHaveAttribute("href", "https://fortifyapp.com");
+
+    expect(
+      screen.getByRole("link", {
+        name: "Get started",
+      })
+    ).toHaveAttribute("href", "https://fortifyapp.com/docs#support");
+  });
+});

--- a/src/components/connection-not-supported/ConnectionNotSupported.tsx
+++ b/src/components/connection-not-supported/ConnectionNotSupported.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from "react-i18next";
+import { Button, Typography } from "@peculiar/react-components";
+import ErrorIcon from "../../icons/error-big.svg?react";
+
+import styles from "./styles/index.module.scss";
+
+export const ConnectionNotSupported = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div className={styles.box}>
+      <div className={styles.content}>
+        <div className={styles.icon_wrapper}>
+          <ErrorIcon />
+        </div>
+        <Typography variant="h5" color="black" className={styles.message}>
+          {t("connection-not-supported.message")}
+        </Typography>
+        <Typography variant="b2" color="gray-9">
+          {t("connection-not-supported.description")}
+        </Typography>
+        <div className={styles.buttons_group}>
+          <Button
+            component="a"
+            href="https://fortifyapp.com"
+            variant="outlined"
+          >
+            {t("connection-not-supported.button.home-page")}
+          </Button>
+          <Button
+            variant="contained"
+            color="primary"
+            component="a"
+            href="https://fortifyapp.com/docs#support"
+          >
+            {t("connection-not-supported.button.get-started")}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/connection-not-supported/index.ts
+++ b/src/components/connection-not-supported/index.ts
@@ -1,0 +1,1 @@
+export * from "./ConnectionNotSupported";

--- a/src/components/connection-not-supported/styles/index.module.scss
+++ b/src/components/connection-not-supported/styles/index.module.scss
@@ -1,0 +1,37 @@
+.box {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  z-index: 1000;
+  background-color: var(--pv-color-gray-2);
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pv-size-base-2);
+  text-align: center;
+  align-items: center;
+  max-width: 230px;
+}
+
+.message {
+  width: 190px;
+}
+
+.icon_wrapper {
+  font-size: 0;
+  padding-bottom: var(--pv-size-base-2);
+}
+
+.buttons_group {
+  padding-top: var(--pv-size-base-4);
+  display: flex;
+  gap: var(--pv-size-base-2);
+}

--- a/src/i18n/locales/en/main.json
+++ b/src/i18n/locales/en/main.json
@@ -227,5 +227,13 @@
       "try-again": "Try again",
       "home-page": "Home page"
     }
+  },
+  "connection-not-supported": {
+    "message": "Unfortunately Fortify isn’t available for mobile devices yet",
+    "description": "Please try again from a Windows, macOS, or Linux computer.",
+    "button": {
+      "get-started": "Get started",
+      "home-page": "Home page"
+    }
   }
 }


### PR DESCRIPTION
Added "not supported" screen, instead dialog
Issue: https://github.com/PeculiarVentures/fortify-tools/issues/230
https://www.figma.com/design/5VYGSxMKzoV1BgewYKFKSd/Fortify?node-id=7469-35399&t=WqWyvSYdylsyZGs3-0

https://github.com/user-attachments/assets/c4fdc7ec-9c11-413c-9c87-bcd80254fffa



